### PR TITLE
Refactored EqualsBuilder::append

### DIFF
--- a/src/test/java/org/mockito/internal/matchers/ArrayEqualsTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ArrayEqualsTest.java
@@ -23,7 +23,7 @@ public class ArrayEqualsTest extends TestBase {
         assertTrue(new ArrayEquals(new Integer[] {1, 2}).matches(new Integer[] {1, 2}));
         assertTrue(new ArrayEquals(new Object[] {"1"}).matches(new Object[] {"1"}));
     }
-    
+
     @Test
     public void shouldArraysMatchTypesWhenNotEqual() throws Exception {
         assertFalse(new ArrayEquals(new boolean[] {true, false}).matches(new boolean[] {false, false}));


### PR DESCRIPTION
Reduced the cyclomatic complexity of append from 15 to 3 by splitting the code into smaller units.

Also removed a whitespace in ArrayEqualsTest.java that made the build fail in main. 

fix #14