### PR TITLE
Implement ListAnyOrder additional matcher

### DIFF
--- a/src/main/java/org/mockito/AdditionalMatchers.java
+++ b/src/main/java/org/mockito/AdditionalMatchers.java
@@ -6,6 +6,8 @@ package org.mockito;
 
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
+import java.util.Collection;
+
 import org.mockito.internal.matchers.ArrayEquals;
 import org.mockito.internal.matchers.CompareEqual;
 import org.mockito.internal.matchers.EqualsWithDelta;
@@ -14,6 +16,7 @@ import org.mockito.internal.matchers.GreaterOrEqual;
 import org.mockito.internal.matchers.GreaterThan;
 import org.mockito.internal.matchers.LessOrEqual;
 import org.mockito.internal.matchers.LessThan;
+import org.mockito.internal.matchers.ListAnyOrder;
 
 /**
  * See {@link ArgumentMatchers} for general info about matchers.
@@ -1049,6 +1052,25 @@ public final class AdditionalMatchers {
     public static float eq(float value, float delta) {
         reportMatcher(new EqualsWithDelta(value, delta));
         return 0;
+    }
+
+    /**
+     * Collection argument that is equal to the given collection, i.e. it has to
+     * have the same size, and each element has to be equal, but not
+     * in the same order. Using deepMatches means the elements can have the
+     * same value but not the same type.
+     * <p>
+     * See examples in javadoc for {@link AdditionalMatchers} class
+     *
+     * @param <T>
+     *            the type of the collection, it is passed through to prevent casts.
+     * @param value
+     *            the given collection.
+     * @return <code>null</code>.
+     */
+    public static <T> Collection<T> lao(Collection<T> value) {
+        reportMatcher(new ListAnyOrder<T>(value));
+        return null;
     }
 
     private static void reportMatcher(ArgumentMatcher<?> matcher) {

--- a/src/main/java/org/mockito/internal/matchers/ListAnyOrder.java
+++ b/src/main/java/org/mockito/internal/matchers/ListAnyOrder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.matchers;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.mockito.ArgumentMatcher;
+
+public class ListAnyOrder<T> implements ArgumentMatcher<Collection<T>>{
+    private final Collection<T> expected;
+
+    public ListAnyOrder(Collection<T> expected) {
+        this.expected = expected;
+    }
+
+    @Override
+    public boolean matches(Collection<T> actual) {
+        if (actual == null || expected == null) {
+            return false;
+        }
+
+        if (actual.size() != expected.size()) {
+            return false;
+        }
+        Object[] expectedArray = expected.toArray();
+        Arrays.sort(expectedArray);
+        Object[] actualArray = actual.toArray();
+        Arrays.sort(actualArray);
+
+        for (int i = 0; i < expectedArray.length; i++) {
+            if (!expectedArray[i].equals(actualArray[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        if (expected == null) {
+            return "null";
+        }
+        return expected.toString();
+    }
+}

--- a/src/test/java/org/mockito/internal/matchers/ListAnyOrderTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListAnyOrderTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.matchers;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.mockitoutil.TestBase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.ArrayDeque;
+
+public class ListAnyOrderTest extends TestBase {
+
+    @Test
+    public void shouldMatchSameElementsDifferentOrderOfLists() {
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
+        List<Integer> list2 = new ArrayList<>(Arrays.asList(2, 1));
+        ListAnyOrder<Integer> listMatcher = new ListAnyOrder<>(list1);
+
+        assertTrue(listMatcher.matches(list2));
+    }
+
+    @Test
+    public void shouldReturnDifferentLengthLists() {
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
+        List<Integer> list2 = new ArrayList<>(Arrays.asList(1));
+        ListAnyOrder<Integer> listMatcher = new ListAnyOrder<>(list1);
+
+        assertFalse(listMatcher.matches(list2));
+    }
+
+    @Test
+    public void shouldReturnDifferentElementsInLists() {
+
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
+        List<Integer> list2 = new ArrayList<>(Arrays.asList(3, 4));
+        ListAnyOrder<Integer> listMatcher = new ListAnyOrder<>(list1);
+
+        assertFalse(listMatcher.matches(list2));
+    }
+
+    @Test
+    public void shouldReturnSameElementsButDifferentListTypes() {
+        List<Integer> list = new ArrayList<>(Arrays.asList(1, 2));
+        Deque<Integer> anotherTypeOfList = new ArrayDeque<>(2);
+        anotherTypeOfList.addFirst(1);
+        anotherTypeOfList.addLast(2);
+        ListAnyOrder<Integer> listMatcher = new ListAnyOrder<>(list);
+
+        assertTrue(listMatcher.matches(anotherTypeOfList));
+    }
+
+    @Test
+    public void shouldReturnDifferentElementsButDifferentListTypes() {
+        List<Integer> list = new ArrayList<>(Arrays.asList(1, 2));
+        Deque<Integer> anotherTypeOfList = new ArrayDeque<>(2);
+        anotherTypeOfList.addFirst(3);
+        anotherTypeOfList.addLast(2);
+        ListAnyOrder<Integer> listAnyOrderObject = new ListAnyOrder<>(list);
+
+        assertFalse(listAnyOrderObject.matches(anotherTypeOfList));
+    }
+
+    @Test
+    public void shouldMatchWhenNull() {
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2, 2, 3));
+        List<Integer> list2 = null;
+        ListAnyOrder<Integer> list1Matcher = new ListAnyOrder<>(list1);
+        ListAnyOrder<Integer> list2Matcher = new ListAnyOrder<>(list2);
+
+        assertFalse(list1Matcher.matches(list2));
+        assertFalse(list2Matcher.matches(list1));
+    }
+
+    @Test
+    public void shouldMatchSameElementsMultipleTimes() {
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2, 2, 3));
+        List<Integer> list2 = new ArrayList<>(Arrays.asList(2, 1, 3, 2));
+        ListAnyOrder<Integer> listMatcher = new ListAnyOrder<>(list1);
+
+        assertTrue(listMatcher.matches(list2));
+    }
+
+    @Test
+    public void shouldReturnToString() {
+        List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3));
+        ListAnyOrder<Integer> listAnyOrderInteger = new ListAnyOrder<>(list);
+        String expectedIntegerString = listAnyOrderInteger.toString();
+
+        List<String> listString = new ArrayList<>(Arrays.asList("1", "2", "3"));
+        ListAnyOrder<String> listAnyOrderString = new ListAnyOrder<>(listString);
+        String expectedStringString = listAnyOrderString.toString();
+
+        assertTrue(expectedIntegerString.equals("[1, 2, 3]"));
+        assertTrue(expectedStringString.equals("[1, 2, 3]"));
+    }
+
+    @Test
+    public void shouldReturnToStringWhenNull() {
+        List<Integer> list = null;
+        ListAnyOrder<Integer> listAnyOrderInteger = new ListAnyOrder<>(list);
+        String expectedIntegerString = listAnyOrderInteger.toString();
+
+        List<String> listString = null;
+        ListAnyOrder<String> listAnyOrderString = new ListAnyOrder<>(listString);
+        String expectedStringString = listAnyOrderString.toString();
+
+        assertTrue(expectedIntegerString.equals("null"));
+        assertTrue(expectedStringString.equals("null"));
+    }
+
+}

--- a/src/test/java/org/mockitousage/IMethods.java
+++ b/src/test/java/org/mockitousage/IMethods.java
@@ -175,6 +175,8 @@ public interface IMethods {
 
     String oneArray(Object[] array);
 
+    String oneList(Collection<?> list);
+
     String canThrowException() throws CharacterCodingException;
 
     String oneArray(String[] array);

--- a/src/test/java/org/mockitousage/MethodsImpl.java
+++ b/src/test/java/org/mockitousage/MethodsImpl.java
@@ -296,9 +296,11 @@ public class MethodsImpl implements IMethods {
         return 0;
     }
 
-    public void twoArgumentMethod(int one, int two) {}
+    public void twoArgumentMethod(int one, int two) {
+    }
 
-    public void arrayMethod(String[] strings) {}
+    public void arrayMethod(String[] strings) {
+    }
 
     public String oneArray(boolean[] array) {
         return null;
@@ -344,7 +346,13 @@ public class MethodsImpl implements IMethods {
         return null;
     }
 
-    public void varargsString(int i, String... string) {}
+    @Override
+    public String oneList(Collection<?> list) {
+        return null;
+    }
+
+    public void varargsString(int i, String... string) {
+    }
 
     public Object varargsObject(int i, Object... object) {
         return null;
@@ -367,7 +375,8 @@ public class MethodsImpl implements IMethods {
         return null;
     }
 
-    public void mixedVarargs(Object i, String... string) {}
+    public void mixedVarargs(Object i, String... string) {
+    }
 
     public String mixedVarargsReturningString(Object i, String... string) {
         return null;
@@ -391,7 +400,8 @@ public class MethodsImpl implements IMethods {
         return "varargs";
     }
 
-    public void varargsbyte(byte... bytes) {}
+    public void varargsbyte(byte... bytes) {
+    }
 
     public List<String> listReturningMethod(Object... objects) {
         return null;
@@ -405,7 +415,8 @@ public class MethodsImpl implements IMethods {
         return null;
     }
 
-    public void voidMethod() {}
+    public void voidMethod() {
+    }
 
     public String forList(List<String> list) {
         return null;
@@ -459,9 +470,11 @@ public class MethodsImpl implements IMethods {
         return null;
     }
 
-    public void longArg(long longArg) {}
+    public void longArg(long longArg) {
+    }
 
-    public void intArgumentMethod(int i) {}
+    public void intArgumentMethod(int i) {
+    }
 
     public int intArgumentReturningInt(int i) {
         return 0;
@@ -507,22 +520,28 @@ public class MethodsImpl implements IMethods {
     }
 
     @Override
-    public void overloadedMethodWithSameClassNameArguments(java.sql.Date javaDate, Date date) {}
+    public void overloadedMethodWithSameClassNameArguments(java.sql.Date javaDate, Date date) {
+    }
 
     @Override
-    public void overloadedMethodWithSameClassNameArguments(Date date, java.sql.Date javaDate) {}
+    public void overloadedMethodWithSameClassNameArguments(Date date, java.sql.Date javaDate) {
+    }
 
     @Override
-    public void overloadedMethodWithDifferentClassNameArguments(String string, Integer i) {}
+    public void overloadedMethodWithDifferentClassNameArguments(String string, Integer i) {
+    }
 
     @Override
-    public void overloadedMethodWithDifferentClassNameArguments(Integer i, String string) {}
+    public void overloadedMethodWithDifferentClassNameArguments(Integer i, String string) {
+    }
 
     @Override
     public void overloadedMethodWithSameClassNameArguments(
-            java.sql.Date javaDate, String string, Date date) {}
+            java.sql.Date javaDate, String string, Date date) {
+    }
 
     @Override
     public void overloadedMethodWithSameClassNameArguments(
-            Date date, String string, java.sql.Date javaDate) {}
+            Date date, String string, java.sql.Date javaDate) {
+    }
 }

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -7,6 +7,7 @@ package org.mockitousage.matchers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.fail;
 import static org.mockito.AdditionalMatchers.and;
@@ -20,6 +21,7 @@ import static org.mockito.AdditionalMatchers.leq;
 import static org.mockito.AdditionalMatchers.lt;
 import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.AdditionalMatchers.or;
+import static org.mockito.AdditionalMatchers.lao;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -51,6 +53,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.RandomAccess;
 import java.util.regex.Pattern;
@@ -324,32 +327,31 @@ public class MatchersTest extends TestBase {
     @Test
     public void should_use_smart_equals_for_arrays() throws Exception {
         // issue 143
-        mock.arrayMethod(new String[] {"one"});
-        verify(mock).arrayMethod(eq(new String[] {"one"}));
-        verify(mock).arrayMethod(new String[] {"one"});
+        mock.arrayMethod(new String[] { "one" });
+        verify(mock).arrayMethod(eq(new String[] { "one" }));
+        verify(mock).arrayMethod(new String[] { "one" });
     }
 
     @Test
     public void should_use_smart_equals_for_primitive_arrays() throws Exception {
         // issue 143
-        mock.objectArgMethod(new int[] {1, 2});
-        verify(mock).objectArgMethod(eq(new int[] {1, 2}));
-        verify(mock).objectArgMethod(new int[] {1, 2});
+        mock.objectArgMethod(new int[] { 1, 2 });
+        verify(mock).objectArgMethod(eq(new int[] { 1, 2 }));
+        verify(mock).objectArgMethod(new int[] { 1, 2 });
     }
 
     @SuppressWarnings("ReturnValueIgnored")
     @Test
-    public void
-            array_equals_should_throw_ArgumentsAreDifferentException_for_non_matching_arguments() {
+    public void array_equals_should_throw_ArgumentsAreDifferentException_for_non_matching_arguments() {
         List<Object> list = Mockito.mock(List.class);
 
         list.add("test"); // testing fix for issue 20
-        list.contains(new Object[] {"1"});
+        list.contains(new Object[] { "1" });
 
         assertThatThrownBy(
-                        () -> {
-                            Mockito.verify(list).contains(new Object[] {"1", "2", "3"});
-                        })
+                () -> {
+                    Mockito.verify(list).contains(new Object[] { "1", "2", "3" });
+                })
                 .isInstanceOf(ArgumentsAreDifferent.class)
                 .hasMessageContainingAll(
                         "Argument(s) are different! Wanted:",
@@ -360,33 +362,33 @@ public class MatchersTest extends TestBase {
 
     @Test
     public void array_equals_matcher() {
-        when(mock.oneArray(aryEq(new boolean[] {true, false, false}))).thenReturn("0");
-        when(mock.oneArray(aryEq(new byte[] {1}))).thenReturn("1");
-        when(mock.oneArray(aryEq(new char[] {1}))).thenReturn("2");
-        when(mock.oneArray(aryEq(new double[] {1}))).thenReturn("3");
-        when(mock.oneArray(aryEq(new float[] {1}))).thenReturn("4");
-        when(mock.oneArray(aryEq(new int[] {1}))).thenReturn("5");
-        when(mock.oneArray(aryEq(new long[] {1}))).thenReturn("6");
-        when(mock.oneArray(aryEq(new short[] {1}))).thenReturn("7");
-        when(mock.oneArray(aryEq(new String[] {"Test"}))).thenReturn("8");
-        when(mock.oneArray(aryEq(new Object[] {"Test", new Integer(4)}))).thenReturn("9");
+        when(mock.oneArray(aryEq(new boolean[] { true, false, false }))).thenReturn("0");
+        when(mock.oneArray(aryEq(new byte[] { 1 }))).thenReturn("1");
+        when(mock.oneArray(aryEq(new char[] { 1 }))).thenReturn("2");
+        when(mock.oneArray(aryEq(new double[] { 1 }))).thenReturn("3");
+        when(mock.oneArray(aryEq(new float[] { 1 }))).thenReturn("4");
+        when(mock.oneArray(aryEq(new int[] { 1 }))).thenReturn("5");
+        when(mock.oneArray(aryEq(new long[] { 1 }))).thenReturn("6");
+        when(mock.oneArray(aryEq(new short[] { 1 }))).thenReturn("7");
+        when(mock.oneArray(aryEq(new String[] { "Test" }))).thenReturn("8");
+        when(mock.oneArray(aryEq(new Object[] { "Test", new Integer(4) }))).thenReturn("9");
 
-        assertEquals("0", mock.oneArray(new boolean[] {true, false, false}));
-        assertEquals("1", mock.oneArray(new byte[] {1}));
-        assertEquals("2", mock.oneArray(new char[] {1}));
-        assertEquals("3", mock.oneArray(new double[] {1}));
-        assertEquals("4", mock.oneArray(new float[] {1}));
-        assertEquals("5", mock.oneArray(new int[] {1}));
-        assertEquals("6", mock.oneArray(new long[] {1}));
-        assertEquals("7", mock.oneArray(new short[] {1}));
-        assertEquals("8", mock.oneArray(new String[] {"Test"}));
-        assertEquals("9", mock.oneArray(new Object[] {"Test", new Integer(4)}));
+        assertEquals("0", mock.oneArray(new boolean[] { true, false, false }));
+        assertEquals("1", mock.oneArray(new byte[] { 1 }));
+        assertEquals("2", mock.oneArray(new char[] { 1 }));
+        assertEquals("3", mock.oneArray(new double[] { 1 }));
+        assertEquals("4", mock.oneArray(new float[] { 1 }));
+        assertEquals("5", mock.oneArray(new int[] { 1 }));
+        assertEquals("6", mock.oneArray(new long[] { 1 }));
+        assertEquals("7", mock.oneArray(new short[] { 1 }));
+        assertEquals("8", mock.oneArray(new String[] { "Test" }));
+        assertEquals("9", mock.oneArray(new Object[] { "Test", new Integer(4) }));
 
-        assertEquals(null, mock.oneArray(new Object[] {"Test", new Integer(999)}));
-        assertEquals(null, mock.oneArray(new Object[] {"Test", new Integer(4), "x"}));
+        assertEquals(null, mock.oneArray(new Object[] { "Test", new Integer(999) }));
+        assertEquals(null, mock.oneArray(new Object[] { "Test", new Integer(4), "x" }));
 
-        assertEquals(null, mock.oneArray(new boolean[] {true, false}));
-        assertEquals(null, mock.oneArray(new boolean[] {true, true, false}));
+        assertEquals(null, mock.oneArray(new boolean[] { true, false }));
+        assertEquals(null, mock.oneArray(new boolean[] { true, true, false }));
     }
 
     @Test
@@ -692,5 +694,50 @@ public class MatchersTest extends TestBase {
         }
 
         verify(mock).oneArg("hello");
+    }
+
+    @Test
+    public void should_list_equals_deal_with_null_list() throws Exception {
+        List<?> nullList = null;
+        when(mock.oneList(lao(nullList))).thenReturn("null");
+
+        mock = mock(IMethods.class);
+
+        try {
+            verify(mock).oneList(lao(nullList));
+            fail();
+        } catch (WantedButNotInvoked e) {
+            assertThat(e).hasMessageContaining("oneList(null)");
+        }
+    }
+
+    @Test
+    public void listsWithSameElementsInAnyOrderShouldMatch() {
+        List<Integer> list1 = Arrays.asList(1, 2, 3);
+        List<Integer> list2 = Arrays.asList(3, 2, 1);
+
+        when(mock.oneList(lao(list1))).thenReturn("matched");
+
+        assertEquals("matched", mock.oneList(list2));
+    }
+
+    @Test
+    public void listsWithDifferentElementsShouldNotMatch() {
+        List<Integer> list1 = Arrays.asList(1, 2, 3);
+        List<Integer> list2 = Arrays.asList(4, 5, 6);
+
+        when(mock.oneList(lao(list1))).thenReturn("matched");
+
+        assertNotEquals("matched", mock.oneList(list2));
+    }
+
+    @Test
+    public void listsWithDuplicateElementsShouldMatchAccordingly() {
+        List<String> list1 = Arrays.asList("a", "b", "b", "c");
+        List<String> list2 = Arrays.asList("c", "b", "a", "b");
+
+        when(mock.oneList(lao(list1))).thenReturn("matched");
+
+        assertEquals("matched", mock.oneList(list2));
     }
 }


### PR DESCRIPTION
Fixes #34, fixes #29, fixes #31, fixes #32. Adds a ListAnyOrder matcher which will match two collections to see compare if they contain the same values, without taking the order of the elements into account.

## Checklist
 - [X] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [X] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [X] If possible / relevant include an example in the description, that could help all including project members to get a better picture of the change
 - [X] Avoid other runtime dependencies
 - [X] Meaningful commit history ; intention is important please rebase your commit history so that each is meaningful and help the people that will explore a change in 2 years
 - [X] The pull request follows coding style
 - [X] Mention `Fixes #<issue number>` in the description _if relevant_
 - [X] At least one commit should mention `Fixes #<issue number>` _if relevant_
