### PR TITLE
Implement ListAnyOrder additional matcher

### DIFF
--- a/src/main/java/org/mockito/AdditionalMatchers.java
+++ b/src/main/java/org/mockito/AdditionalMatchers.java
@@ -6,6 +6,8 @@ package org.mockito;
 
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
+import java.util.Collection;
+
 import org.mockito.internal.matchers.ArrayEquals;
 import org.mockito.internal.matchers.CompareEqual;
 import org.mockito.internal.matchers.EqualsWithDelta;
@@ -14,6 +16,7 @@ import org.mockito.internal.matchers.GreaterOrEqual;
 import org.mockito.internal.matchers.GreaterThan;
 import org.mockito.internal.matchers.LessOrEqual;
 import org.mockito.internal.matchers.LessThan;
+import org.mockito.internal.matchers.ListAnyOrder;
 
 /**
  * See {@link ArgumentMatchers} for general info about matchers.
@@ -1049,6 +1052,25 @@ public final class AdditionalMatchers {
     public static float eq(float value, float delta) {
         reportMatcher(new EqualsWithDelta(value, delta));
         return 0;
+    }
+
+    /**
+     * Collection argument that is equal to the given collection, i.e. it has to
+     * have the same size, and each element has to be equal, but not
+     * in the same order. Using deepMatches means the elements can have the
+     * same value but not the same type.
+     * <p>
+     * See examples in javadoc for {@link AdditionalMatchers} class
+     *
+     * @param <T>
+     *            the type of the collection, it is passed through to prevent casts.
+     * @param value
+     *            the given collection.
+     * @return <code>null</code>.
+     */
+    public static <T> Collection<T> lao(Collection<T> value) {
+        reportMatcher(new ListAnyOrder<T>(value));
+        return null;
     }
 
     private static void reportMatcher(ArgumentMatcher<?> matcher) {

--- a/src/main/java/org/mockito/internal/matchers/ListAnyOrder.java
+++ b/src/main/java/org/mockito/internal/matchers/ListAnyOrder.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.matchers;
 
+import java.util.Arrays;
 import java.util.Collection;
 import org.mockito.ArgumentMatcher;
 
@@ -16,18 +17,31 @@ public class ListAnyOrder<T> implements ArgumentMatcher<Collection<T>>{
 
     @Override
     public boolean matches(Collection<T> actual) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'matches'");
-    }
+        if (actual == null || expected == null) {
+            return false;
+        }
 
-    public <E> boolean deepMatches(Collection<E> actual) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'deepMatches'");
+        if (actual.size() != expected.size()) {
+            return false;
+        }
+        Object[] expectedArray = expected.toArray();
+        Arrays.sort(expectedArray);
+        Object[] actualArray = actual.toArray();
+        Arrays.sort(actualArray);
+
+        for (int i = 0; i < expectedArray.length; i++) {
+            if (!expectedArray[i].equals(actualArray[i])) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
     public String toString() {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'toString'");
-    }    
+        if (expected == null) {
+            return "null";
+        }
+        return expected.toString();
+    }
 }

--- a/src/main/java/org/mockito/internal/matchers/ListAnyOrder.java
+++ b/src/main/java/org/mockito/internal/matchers/ListAnyOrder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.matchers;
+
+import java.util.Collection;
+import org.mockito.ArgumentMatcher;
+
+public class ListAnyOrder<T> implements ArgumentMatcher<Collection<T>>{
+    private final Collection<T> expected;
+
+    public ListAnyOrder(Collection<T> expected) {
+        this.expected = expected;
+    }
+
+    @Override
+    public boolean matches(Collection<T> actual) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'matches'");
+    }
+
+    public <E> boolean deepMatches(Collection<E> actual) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'deepMatches'");
+    }
+
+    @Override
+    public String toString() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'toString'");
+    }    
+}

--- a/src/test/java/org/mockito/internal/matchers/ListAnyOrderTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListAnyOrderTest.java
@@ -17,85 +17,101 @@ import java.util.ArrayDeque;
 
 public class ListAnyOrderTest extends TestBase {
 
-    @Test 
-    public void shouldMatchSameElementsDifferentOrderOfLists(){
+    @Test
+    public void shouldMatchSameElementsDifferentOrderOfLists() {
         List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
         List<Integer> list2 = new ArrayList<>(Arrays.asList(2, 1));
-        ListAnyOrder<Integer> list = new ListAnyOrder<>(list1);
+        ListAnyOrder<Integer> listMatcher = new ListAnyOrder<>(list1);
 
-        assertTrue(list.matches(list2));
-    }
-
-    @Test 
-    public void shouldReturnDifferentLengthLists(){
-        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
-        List<Integer> list2 = new ArrayList<>(Arrays.asList(1));
-        ListAnyOrder<Integer> list = new ListAnyOrder<>(list1);
-
-        assertFalse(list.matches(list2));
+        assertTrue(listMatcher.matches(list2));
     }
 
     @Test
-    public void shouldReturnDifferentElementsInLists(){
+    public void shouldReturnDifferentLengthLists() {
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
+        List<Integer> list2 = new ArrayList<>(Arrays.asList(1));
+        ListAnyOrder<Integer> listMatcher = new ListAnyOrder<>(list1);
+
+        assertFalse(listMatcher.matches(list2));
+    }
+
+    @Test
+    public void shouldReturnDifferentElementsInLists() {
 
         List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
         List<Integer> list2 = new ArrayList<>(Arrays.asList(3, 4));
-        ListAnyOrder<Integer> listAnyOrderObject = new ListAnyOrder<>(list1);
+        ListAnyOrder<Integer> listMatcher = new ListAnyOrder<>(list1);
 
-        assertFalse(listAnyOrderObject.matches(list2));
+        assertFalse(listMatcher.matches(list2));
     }
-    
+
     @Test
-    public void shouldReturnSameElementsButDifferentListTypes(){
+    public void shouldReturnSameElementsButDifferentListTypes() {
         List<Integer> list = new ArrayList<>(Arrays.asList(1, 2));
         Deque<Integer> anotherTypeOfList = new ArrayDeque<>(2);
         anotherTypeOfList.addFirst(1);
         anotherTypeOfList.addLast(2);
-        ListAnyOrder<Integer> listAnyOrderObject = new ListAnyOrder<>(list);
-        
-        assertTrue(listAnyOrderObject.matches(anotherTypeOfList));
+        ListAnyOrder<Integer> listMatcher = new ListAnyOrder<>(list);
+
+        assertTrue(listMatcher.matches(anotherTypeOfList));
     }
 
     @Test
-    public void shouldReturnDifferentElementsButDifferentListTypes(){
+    public void shouldReturnDifferentElementsButDifferentListTypes() {
         List<Integer> list = new ArrayList<>(Arrays.asList(1, 2));
         Deque<Integer> anotherTypeOfList = new ArrayDeque<>(2);
         anotherTypeOfList.addFirst(3);
         anotherTypeOfList.addLast(2);
         ListAnyOrder<Integer> listAnyOrderObject = new ListAnyOrder<>(list);
-        
+
         assertFalse(listAnyOrderObject.matches(anotherTypeOfList));
     }
-    
-    @Test
-    public void shouldDeepMatchSameElementsDifferentClassesDifferentOrder(){
-        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
-        List<Short> list2 = new ArrayList<>(List.of((short) 2, (short) 1));
-        ListAnyOrder<Integer> list = new ListAnyOrder<>(list1);
 
-        assertTrue(list.deepMatches(list2));
-    }
-    
     @Test
-    public void shouldDeepMatchDifferentElementsDifferentClasses(){
-        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
-        List<Short> list2 = new ArrayList<>(List.of((short) 2, (short) 3));
-        ListAnyOrder<Integer> list = new ListAnyOrder<>(list1);
-        
-        assertFalse(list.deepMatches(list2));
+    public void shouldMatchWhenNull() {
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2, 2, 3));
+        List<Integer> list2 = null;
+        ListAnyOrder<Integer> list1Matcher = new ListAnyOrder<>(list1);
+        ListAnyOrder<Integer> list2Matcher = new ListAnyOrder<>(list2);
+
+        assertFalse(list1Matcher.matches(list2));
+        assertFalse(list2Matcher.matches(list1));
     }
 
-    @Test 
-    public void shouldReturnToString(){
-        List<Integer> list = new ArrayList<>(Arrays.asList(1,2,3));
+    @Test
+    public void shouldMatchSameElementsMultipleTimes() {
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2, 2, 3));
+        List<Integer> list2 = new ArrayList<>(Arrays.asList(2, 1, 3, 2));
+        ListAnyOrder<Integer> listMatcher = new ListAnyOrder<>(list1);
+
+        assertTrue(listMatcher.matches(list2));
+    }
+
+    @Test
+    public void shouldReturnToString() {
+        List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3));
         ListAnyOrder<Integer> listAnyOrderInteger = new ListAnyOrder<>(list);
         String expectedIntegerString = listAnyOrderInteger.toString();
 
-        List<String> listString = new ArrayList<>(Arrays.asList("1","2","3"));
+        List<String> listString = new ArrayList<>(Arrays.asList("1", "2", "3"));
         ListAnyOrder<String> listAnyOrderString = new ListAnyOrder<>(listString);
         String expectedStringString = listAnyOrderString.toString();
 
         assertTrue(expectedIntegerString.equals("[1, 2, 3]"));
         assertTrue(expectedStringString.equals("[1, 2, 3]"));
+    }
+
+    @Test
+    public void shouldReturnToStringWhenNull() {
+        List<Integer> list = null;
+        ListAnyOrder<Integer> listAnyOrderInteger = new ListAnyOrder<>(list);
+        String expectedIntegerString = listAnyOrderInteger.toString();
+
+        List<String> listString = null;
+        ListAnyOrder<String> listAnyOrderString = new ListAnyOrder<>(listString);
+        String expectedStringString = listAnyOrderString.toString();
+
+        assertTrue(expectedIntegerString.equals("null"));
+        assertTrue(expectedStringString.equals("null"));
     }
 }

--- a/src/test/java/org/mockito/internal/matchers/ListAnyOrderTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListAnyOrderTest.java
@@ -89,11 +89,13 @@ public class ListAnyOrderTest extends TestBase {
     public void shouldReturnToString(){
         List<Integer> list = new ArrayList<>(Arrays.asList(1,2,3));
         ListAnyOrder<Integer> listAnyOrderInteger = new ListAnyOrder<>(list);
+        String expectedIntegerString = listAnyOrderInteger.toString();
 
         List<String> listString = new ArrayList<>(Arrays.asList("1","2","3"));
         ListAnyOrder<String> listAnyOrderString = new ListAnyOrder<>(listString);
+        String expectedStringString = listAnyOrderString.toString();
 
-        assertTrue(listAnyOrderInteger.toString().equals("[1, 2]"));
-        assertTrue(listAnyOrderString.toString().equals("[\"1\", \"2\", \"3\"]"));
-    }    
+        assertTrue(expectedIntegerString.equals("[1, 2, 3]"));
+        assertTrue(expectedStringString.equals("[1, 2, 3]"));
+    }
 }

--- a/src/test/java/org/mockito/internal/matchers/ListAnyOrderTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListAnyOrderTest.java
@@ -22,6 +22,7 @@ public class ListAnyOrderTest extends TestBase {
         List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
         List<Integer> list2 = new ArrayList<>(Arrays.asList(2, 1));
         ListAnyOrder<Integer> list = new ListAnyOrder<>(list1);
+
         assertTrue(list.matches(list2));
     }
 
@@ -54,12 +55,24 @@ public class ListAnyOrderTest extends TestBase {
         
         assertTrue(listAnyOrderObject.matches(anotherTypeOfList));
     }
+
+    @Test
+    public void shouldReturnDifferentElementsButDifferentListTypes(){
+        List<Integer> list = new ArrayList<>(Arrays.asList(1, 2));
+        Deque<Integer> anotherTypeOfList = new ArrayDeque<>(2);
+        anotherTypeOfList.addFirst(3);
+        anotherTypeOfList.addLast(2);
+        ListAnyOrder<Integer> listAnyOrderObject = new ListAnyOrder<>(list);
+        
+        assertFalse(listAnyOrderObject.matches(anotherTypeOfList));
+    }
     
     @Test
     public void shouldDeepMatchSameElementsDifferentClassesDifferentOrder(){
         List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
         List<Short> list2 = new ArrayList<>(List.of((short) 2, (short) 1));
         ListAnyOrder<Integer> list = new ListAnyOrder<>(list1);
+
         assertTrue(list.deepMatches(list2));
     }
     
@@ -68,6 +81,7 @@ public class ListAnyOrderTest extends TestBase {
         List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
         List<Short> list2 = new ArrayList<>(List.of((short) 2, (short) 3));
         ListAnyOrder<Integer> list = new ListAnyOrder<>(list1);
+        
         assertFalse(list.deepMatches(list2));
     }
 

--- a/src/test/java/org/mockito/internal/matchers/ListAnyOrderTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListAnyOrderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.matchers;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.mockitoutil.TestBase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.ArrayDeque;
+
+public class ListAnyOrderTest extends TestBase {
+
+    @Test 
+    public void shouldMatchSameElementsDifferentOrderOfLists(){
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
+        List<Integer> list2 = new ArrayList<>(Arrays.asList(2, 1));
+        ListAnyOrder<Integer> list = new ListAnyOrder<>(list1);
+        assertTrue(list.matches(list2));
+    }
+
+    @Test 
+    public void shouldReturnDifferentLengthLists(){
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
+        List<Integer> list2 = new ArrayList<>(Arrays.asList(1));
+        ListAnyOrder<Integer> list = new ListAnyOrder<>(list1);
+
+        assertFalse(list.matches(list2));
+    }
+
+    @Test
+    public void shouldReturnDifferentElementsInLists(){
+
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
+        List<Integer> list2 = new ArrayList<>(Arrays.asList(3, 4));
+        ListAnyOrder<Integer> listAnyOrderObject = new ListAnyOrder<>(list1);
+
+        assertFalse(listAnyOrderObject.matches(list2));
+    }
+    
+    @Test
+    public void shouldReturnSameElementsButDifferentListTypes(){
+        List<Integer> list = new ArrayList<>(Arrays.asList(1, 2));
+        Deque<Integer> anotherTypeOfList = new ArrayDeque<>(2);
+        anotherTypeOfList.addFirst(1);
+        anotherTypeOfList.addLast(2);
+        ListAnyOrder<Integer> listAnyOrderObject = new ListAnyOrder<>(list);
+        
+        assertTrue(listAnyOrderObject.matches(anotherTypeOfList));
+    }
+    
+    @Test
+    public void shouldDeepMatchSameElementsDifferentClassesDifferentOrder(){
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
+        List<Short> list2 = new ArrayList<>(List.of((short) 2, (short) 1));
+        ListAnyOrder<Integer> list = new ListAnyOrder<>(list1);
+        assertTrue(list.deepMatches(list2));
+    }
+    
+    @Test
+    public void shouldDeepMatchDifferentElementsDifferentClasses(){
+        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 2));
+        List<Short> list2 = new ArrayList<>(List.of((short) 2, (short) 3));
+        ListAnyOrder<Integer> list = new ListAnyOrder<>(list1);
+        assertFalse(list.deepMatches(list2));
+    }
+
+    @Test 
+    public void shouldReturnToString(){
+        List<Integer> list = new ArrayList<>(Arrays.asList(1,2,3));
+        ListAnyOrder<Integer> listAnyOrderInteger = new ListAnyOrder<>(list);
+
+        List<String> listString = new ArrayList<>(Arrays.asList("1","2","3"));
+        ListAnyOrder<String> listAnyOrderString = new ListAnyOrder<>(listString);
+
+        assertTrue(listAnyOrderInteger.toString().equals("[1, 2]"));
+        assertTrue(listAnyOrderString.toString().equals("[\"1\", \"2\", \"3\"]"));
+    }    
+}

--- a/src/test/java/org/mockitousage/IMethods.java
+++ b/src/test/java/org/mockitousage/IMethods.java
@@ -175,6 +175,8 @@ public interface IMethods {
 
     String oneArray(Object[] array);
 
+    String oneList(Collection<?> list);
+
     String canThrowException() throws CharacterCodingException;
 
     String oneArray(String[] array);

--- a/src/test/java/org/mockitousage/MethodsImpl.java
+++ b/src/test/java/org/mockitousage/MethodsImpl.java
@@ -344,6 +344,11 @@ public class MethodsImpl implements IMethods {
         return null;
     }
 
+    @Override
+    public String oneList(Collection<?> list) {
+        return null;
+    }
+
     public void varargsString(int i, String... string) {}
 
     public Object varargsObject(int i, Object... object) {

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -7,6 +7,7 @@ package org.mockitousage.matchers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.fail;
 import static org.mockito.AdditionalMatchers.and;
@@ -20,6 +21,7 @@ import static org.mockito.AdditionalMatchers.leq;
 import static org.mockito.AdditionalMatchers.lt;
 import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.AdditionalMatchers.or;
+import static org.mockito.AdditionalMatchers.lao;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -51,6 +53,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.RandomAccess;
 import java.util.regex.Pattern;
@@ -692,5 +695,50 @@ public class MatchersTest extends TestBase {
         }
 
         verify(mock).oneArg("hello");
+    }
+
+    @Test
+    public void should_list_equals_deal_with_null_list() throws Exception {
+        List<?> nullList = null;
+        when(mock.oneList(lao(nullList))).thenReturn("null");
+
+        mock = mock(IMethods.class);
+
+        try {
+            verify(mock).oneList(lao(nullList));
+            fail();
+        } catch (WantedButNotInvoked e) {
+            assertThat(e).hasMessageContaining("oneList(null)");
+        }
+    }
+
+    @Test
+    public void lists_with_same_elements_in_any_order_should_match() {
+        List<Integer> list1 = Arrays.asList(1, 2, 3);
+        List<Integer> list2 = Arrays.asList(3, 2, 1);
+
+        when(mock.oneList(lao(list1))).thenReturn("matched");
+
+        assertEquals("matched", mock.oneList(list2));
+    }
+
+    @Test
+    public void lists_with_different_elements_should_not_match() {
+        List<Integer> list1 = Arrays.asList(1, 2, 3);
+        List<Integer> list2 = Arrays.asList(4, 5, 6);
+
+        when(mock.oneList(lao(list1))).thenReturn("matched");
+
+        assertNotEquals("matched", mock.oneList(list2));
+    }
+
+    @Test
+    public void lists_with_duplicate_elements_should_match_accordingly() {
+        List<String> list1 = Arrays.asList("a", "b", "b", "c");
+        List<String> list2 = Arrays.asList("c", "b", "a", "b");
+
+        when(mock.oneList(lao(list1))).thenReturn("matched");
+
+        assertEquals("matched", mock.oneList(list2));
     }
 }


### PR DESCRIPTION
Fixes #34. Adds a ListAnyOrder matcher which will match two collections to see compare if they contain the same values, without taking the order of the elements into account.

## Checklist
 - [X] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [X] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [X] If possible / relevant include an example in the description, that could help all including project members to get a better picture of the change
 - [X] Avoid other runtime dependencies
 - [X] Meaningful commit history ; intention is important please rebase your commit history so that each is meaningful and help the people that will explore a change in 2 years
 - [X] The pull request follows coding style
 - [X] Mention `Fixes #<issue number>` in the description _if relevant_
 - [X] At least one commit should mention `Fixes #<issue number>` _if relevant_
